### PR TITLE
delete unused import in flutter routes

### DIFF
--- a/FlutterService/flutter_routes.py
+++ b/FlutterService/flutter_routes.py
@@ -6,7 +6,6 @@ from flask import Blueprint, request, jsonify
 import io
 from Grocery.Receipt import Receipt
 from Grocery.StoreProduct import StoreProduct
-from mongoClient.mongo_client import mongoClient
 from NameProcessing.NameProcessor import NameProcessor
 from mongoClient.mongo_client import MongoConnector
 


### PR DESCRIPTION
I had to delete the mongoClient object import statement since it is unused and now does not exist. This was causing an error. 